### PR TITLE
Short and sweet

### DIFF
--- a/DailyWTF_Comment_Cleaner.user.js
+++ b/DailyWTF_Comment_Cleaner.user.js
@@ -10,24 +10,6 @@
 
 (function() {
     'use strict';
-    var names = ['B L A K E Y R A T','Blakeyrat','b?keyrat','blameyrat','Fuck you alex','bläkeyrat','blockyrat','Ulysses','B lALye key RraBlaRAT','B lALye key RraBlaRAT',
-                 'Bla-key-rat','blaKEY RaT','CHARLIEMOUSE','TenshiNo','b l a k e y r a t','blakeyrat','BonkeyRatt','BarfyRoot',
-                'bakedrat'];
-    var contains = '';
-    for (var i = 0; i < names.length; i++) {
-        if (i > 0) contains += ", ";
-        contains += "span.poster:contains('" + names[i] + "')";
-    }
-    //.comments>.comment { max-height:20em; overflow-y:auto; }
-    $(".comments > .comment").css({maxHeight: '20em', overflow: 'auto' });
-    //.comments>.comment>div>img{display:none}
-    $(".comments > .comment > div > img").css("display", "none");
-    $("li.comment").filter(function(index) {
-        return (
-            $(this).children(contains).length > 0 &&
-            $(this).children("span.poster-anon:contains('(unregistered)')").length > 0);
-    }).hide();
-    $(function(){
-        $('*').remove('img[src*="meatspin"]');
-    });
+    $(".comments > .comment").css({maxHeight: '24em', overflow: 'auto' });
+    $(".comments > .comment img").css({'height': '2px', 'width': '2px'});
 })();


### PR DESCRIPTION
This does the trick for me. Comments, with line numbers based on the original:
- Lines 13:20: Trying to keep track of Blakeyrat's aliases is a waste of time. Life is too short.
- Lines 21:22: Setting the maxHeight of comments helps a lot. I bumped it from 20em to 24em because there are a few legitimate comments that just need a touch more room.
- Lines 23:24: I keep the images showing, but at a size of 2x2, so I know they're there in case I should ever want to see one. Sometimes there are babies in the bathwater.
- Lines 25:29: Removing children is another interesting solution but I'm concerned about those babies.
- Lines 30:32: Hiding that particular image is a great idea--but he just needs to rename it and you have the same problem as in lines 13:20.